### PR TITLE
Final story 1

### DIFF
--- a/app/controllers/merchant/bulk_discounts_controller.rb
+++ b/app/controllers/merchant/bulk_discounts_controller.rb
@@ -1,0 +1,24 @@
+class Merchant::BulkDiscountsController < Merchant::BaseController
+
+  def new
+    @merchant = Merchant.find(current_user.merchant_id)
+  end
+  
+  def create
+    @merchant = Merchant.find(current_user.merchant_id)
+    if @merchant.bulk_discounts.create(discount_params)
+      flash[:success] = "Discount Saved: #{discount_params[:title]} #{discount_params[:percent_discount]}% off of a group of like items when you purchase #{discount_params[:minimum_item_quantity]}!"
+      redirect_to "/merchant"
+    else
+      flash[:error] = @merchant.errors.full_messages.to_sentence
+      render :new
+    end
+  end
+  
+  private
+  
+  def discount_params
+    params.permit(:title, :minimum_item_quantity, :percent_discount)
+  end
+  
+end

--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -1,0 +1,7 @@
+class BulkDiscount < ApplicationRecord
+  belongs_to :merchant
+  
+  validates_presence_of :merchant_id,
+                        :minimum_item_quantity,
+                        :percent_discount
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,6 +2,7 @@ class Merchant <ApplicationRecord
   has_many :items, dependent: :destroy
   has_many :item_orders, through: :items
   has_many :users
+  has_many :bulk_discounts
 
   validates_presence_of :name,
                         :address,

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -4,6 +4,10 @@
 <% else %>
   <h1>All Items</h1>
 <% end %>
+<p align="center">Current Discounts: </p>
+<% @merchant.bulk_discounts.each do |discount|%>
+  <p align="center"><%= "#{discount.title} #{discount.percent_discount.to_i}% off a group of like items when you purchase #{discount.minimum_item_quantity}!" %> </p>
+<% end %>
 <section class="grid-container">
   <% @items.each do |item| %>
     <% if item.active? %>

--- a/app/views/merchant/bulk_discounts/new.html.erb
+++ b/app/views/merchant/bulk_discounts/new.html.erb
@@ -1,0 +1,14 @@
+<center>
+  <%= form_tag "/merchant/bulk_discounts", method: :post do %>
+    <%= label_tag "Discount Title" %>
+    <%= text_field_tag :title%>
+
+    <%= label_tag "Minimum Items For Discount" %>
+    <%= text_field_tag :minimum_item_quantity %>
+
+    <%= label_tag "Percentage Discount" %>
+    <%= text_field_tag :percent_discount %>
+
+    <%= submit_tag 'Create This Discount' %>
+  <% end %>
+</center>

--- a/app/views/merchant/dashboard/index.html.erb
+++ b/app/views/merchant/dashboard/index.html.erb
@@ -6,6 +6,9 @@
     <%= @merchant.state %>
     <%= @merchant.zip %>
   </section>
+  
+<p><%= link_to "My Items", "/merchant/items" %></p>
+<p><%= link_to "Set My Discounts", "/merchant/bulk_discounts" %></p>
 
 <h3>Pending Orders:</h3>
 <% @merchant.pending_orders.each do |order| %>
@@ -16,4 +19,4 @@
       <li>Total Value: $<%= order.total_item_value(@merchant.id) %></li>
 <% end %>
 
-<p><%= link_to "My Items", "/merchant/items" %></p>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,10 +10,14 @@ Rails.application.routes.draw do
   end
 
   namespace :merchant do
-    get '/', to: "dashboard#index"
     resources :items, only: [:index, :show, :create, :new]
-    post '/items/new', to: "/merchant/items#new"
     resources :orders, only: [:show, :update]
+
+    get "/bulk_discounts", to: "bulk_discounts#new"
+    post "/bulk_discounts", to: "bulk_discounts#create"
+    
+    get '/', to: "dashboard#index"
+    post '/items/new', to: "/merchant/items#new"
     patch "/orders/:order_id/items/:item_id/update", to: "orders#update"
     patch "/items/:id", to: "items#update_activation"
     delete "/items/:id", to: "items#destroy"

--- a/db/migrate/20200919030619_create_bulk_discounts.rb
+++ b/db/migrate/20200919030619_create_bulk_discounts.rb
@@ -1,0 +1,11 @@
+class CreateBulkDiscounts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :bulk_discounts do |t|
+      t.references :merchant, foreign_key: true
+      t.integer :minimum_item_quantity
+      t.float :percent_discount
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200919031808_add_title_to_bulk_discounts.rb
+++ b/db/migrate/20200919031808_add_title_to_bulk_discounts.rb
@@ -1,0 +1,5 @@
+class AddTitleToBulkDiscounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bulk_discounts, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_14_233152) do
+ActiveRecord::Schema.define(version: 2020_09_19_031808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bulk_discounts", force: :cascade do |t|
+    t.bigint "merchant_id"
+    t.integer "minimum_item_quantity"
+    t.float "percent_discount"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.index ["merchant_id"], name: "index_bulk_discounts_on_merchant_id"
+  end
 
   create_table "item_orders", force: :cascade do |t|
     t.bigint "order_id"
@@ -87,6 +97,7 @@ ActiveRecord::Schema.define(version: 2020_09_14_233152) do
     t.index ["merchant_id"], name: "index_users_on_merchant_id"
   end
 
+  add_foreign_key "bulk_discounts", "merchants"
   add_foreign_key "item_orders", "items"
   add_foreign_key "item_orders", "orders"
   add_foreign_key "items", "merchants"

--- a/final_stories.md
+++ b/final_stories.md
@@ -11,3 +11,8 @@ When a user adds enough value or quantity of a single item to their cart, the bu
 When there is a conflict between two discounts, the greater of the two will be applied.
 
 Final discounted prices should appear on the orders show page.
+
+bulk_discounts
+merchant:refernces
+minimum_item_quantity:integer
+percent_discount:float

--- a/final_stories.md
+++ b/final_stories.md
@@ -1,0 +1,13 @@
+As a Merchant
+
+When I visit my dashboard (/merchant/dashboard), I see a link to apply discounts
+
+As a Default User
+
+After my discounts are set, I see the discount terms on the (/merchant/:id/items)
+
+When a user adds enough value or quantity of a single item to their cart, the bulk discount will automatically show up on the cart page.
+
+When there is a conflict between two discounts, the greater of the two will be applied.
+
+Final discounted prices should appear on the orders show page.

--- a/spec/features/merchant/bulk_discounts/new_spec.rb
+++ b/spec/features/merchant/bulk_discounts/new_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe "As a merchant employee" do
+  before :each do
+    @meg = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+
+    @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+
+    @employee_user = User.create!(name: "Mary Jane", address: "1234 Bland St.", city: "Denver", state: "CO", zip: "80085", email: "regular_user@email.com", password: "123", role: 1, merchant_id: @meg.id)
+
+    visit '/'
+    
+    within ".topnav" do
+      click_link("Login")
+    end
+    
+    fill_in :email, with: @employee_user.email
+    fill_in :password, with: @employee_user.password
+    click_on "Submit"
+    click_link("Merchant Dashboard")
+    expect(current_path).to eq("/merchant")
+
+  end
+  
+  it "I see a link to apply bulk discounts, when I click this link I can define the discount and submit it in a form" do
+  
+    click_link "Set My Discounts"
+    
+    expect(current_path).to eq("/merchant/bulk_discounts")
+    
+    expect(BulkDiscount.last).to eq(nil)
+    
+    fill_in :title, with: "Labor Day Sale!"
+    fill_in :minimum_item_quantity, with: "5"
+    fill_in :percent_discount, with: "25"
+    
+    click_on "Create This Discount"
+    
+    expect(current_path).to eq("/merchant")
+    expect(page).to have_content("Discount Saved: Labor Day Sale! 25% off of a group of like items when you purchase 5!")
+    expect(BulkDiscount.last).to_not eq(nil)
+    
+    visit "/merchants/#{@meg.id}/items"
+    expect(page).to have_content("Labor Day Sale! 25% off a group of like items when you purchase 5!")
+    
+    
+  end
+end

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe BulkDiscount, type: :model do
+  
+  describe "validations" do
+    it { should validate_presence_of :merchant_id }
+    it { should validate_presence_of :minimum_item_quantity }
+    it { should validate_presence_of :percent_discount }
+  end
+  
+  describe "relationships" do
+    it {should belong_to :merchant}
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -11,6 +11,7 @@ describe Merchant, type: :model do
 
   describe "relationships" do
     it {should have_many :items}
+    it {should have_many :bulk_discounts}
     it {should have_many(:item_orders).through(:items)}
   end
 


### PR DESCRIPTION
As a Merchant

When I visit my dashboard (/merchant/dashboard), I see a link to apply discounts

As a Default User

After my discounts are set, I see the discount terms on the (/merchant/:id/items)

When a user adds enough value or quantity of a single item to their cart, the bulk discount will automatically show up on the cart page.

When there is a conflict between two discounts, the greater of the two will be applied.

Final discounted prices should appear on the orders show page.

bulk_discounts
merchant:refernces
minimum_item_quantity:integer
percent_discount:float